### PR TITLE
add automatic GitHub release creation

### DIFF
--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -14,7 +14,6 @@ jobs:
   call-tmpl-build-release:
     uses: ./.github/workflows/tmpl-build-release.yml
     with:
-      autoversion: true
       skippublish: ${{ inputs.skippublish }}
     secrets:
       apikey: $env:APIKEY

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -1,0 +1,17 @@
+on:
+  workflow_dispatch:
+    inputs:
+      skippublish:
+        description: "Determines if the publishing to the PowerShell Gallery is skipped"
+        default: false
+        required: false
+        type: boolean
+
+jobs:
+  call-tmpl-build-release:
+    uses: ./.github/workflow/tmpl-build-release.yml
+      with:
+        autoversion: true
+        skippublish: ${{ inputs.skippublish }}
+      secrets:
+        apikey: $env:APIKEY

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -3,9 +3,12 @@ on:
     inputs:
       skippublish:
         description: "Determines if the publishing to the PowerShell Gallery is skipped"
-        default: false
+        default: $True
         required: false
-        type: boolean
+        type: choice
+        options:
+          - $False
+          - $True
 
 jobs:
   call-tmpl-build-release:

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -25,4 +25,4 @@ jobs:
       skippublish: ${{ inputs.skippublish }}
       skipghrelease: ${{ inputs.skipghrelease }}
     secrets:
-      apikey: $env:APIKEY
+      apikey: ${{ secrets.ApiKey }}

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -9,9 +9,9 @@ on:
 
 jobs:
   call-tmpl-build-release:
-    uses: ./.github/workflow/tmpl-build-release.yml
-      with:
-        autoversion: true
-        skippublish: ${{ inputs.skippublish }}
-      secrets:
-        apikey: $env:APIKEY
+    uses: ./.github/workflows/tmpl-build-release.yml
+    with:
+      autoversion: true
+      skippublish: ${{ inputs.skippublish }}
+    secrets:
+      apikey: $env:APIKEY

--- a/.github/workflows/build-manual.yml
+++ b/.github/workflows/build-manual.yml
@@ -9,11 +9,20 @@ on:
         options:
           - $False
           - $True
+      skipghrelease:
+        description: "Determines if creation of a GitHub release is skipped"
+        default: $False
+        required: false
+        type: choice
+        options:
+          - $False
+          - $True
 
 jobs:
   call-tmpl-build-release:
     uses: ./.github/workflows/tmpl-build-release.yml
     with:
       skippublish: ${{ inputs.skippublish }}
+      skipghrelease: ${{ inputs.skipghrelease }}
     secrets:
       apikey: $env:APIKEY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,20 +5,10 @@
       - main
 
 jobs:
-  build:
-
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v1
-    - name: Install Prerequisites
-      run: .\build\vsts-prerequisites.ps1
-      shell: powershell
-    - name: Validate
-      run: .\build\vsts-validate.ps1
-      shell: powershell
-    - name: Build
-      run: .\build\vsts-build.ps1 -ApiKey $env:APIKEY -AutoVersion
-      shell: powershell
-      env:
-        APIKEY: ${{ secrets.ApiKey }}
+  call-tmpl-build-release:
+    uses: ./.github/workflows/tmpl-build-release.yml
+    with:
+      skippublish: $False
+      skipghrelease: $False
+    secrets:
+      apikey: $env:APIKEY

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,4 +11,4 @@ jobs:
       skippublish: $False
       skipghrelease: $False
     secrets:
-      apikey: $env:APIKEY
+      apikey: ${{ secrets.ApiKey }}

--- a/.github/workflows/tmpl-build-release.yml
+++ b/.github/workflows/tmpl-build-release.yml
@@ -10,14 +10,14 @@ on:
     inputs:
       autoversion:
         description: "Determines if the module's build version number is automatically incremented"
-        default: true
+        default: $True
         required: false
-        type: boolean
+        type: string
       skippublish:
         description: "Determines if the publishing to the PowerShell Gallery is skipped"
-        default: false
+        default: $False
         required: false
-        type: boolean
+        type: string
     secrets:
       apikey:
         description: "Key for the PowerShell Gallery API"

--- a/.github/workflows/tmpl-build-release.yml
+++ b/.github/workflows/tmpl-build-release.yml
@@ -47,7 +47,7 @@ jobs:
     
     - name: Get version
       run: |
-        $publishDir = Get-Item -Path publish -ItemType Directory
+        $publishDir = Get-Item -Path publish
         [version]$version = (Import-PowerShellDataFile -Path "$($publishDir.FullName)\d365bap.tools\d365bap.tools.psd1").ModuleVersion
         $githubReleaseVersion = "$($version.Major).$($version.Minor).$($version.Build)"
         "VERSION=$githubReleaseVersion" >> $env:GITHUB_ENV

--- a/.github/workflows/tmpl-build-release.yml
+++ b/.github/workflows/tmpl-build-release.yml
@@ -47,7 +47,8 @@ jobs:
     
     - name: Get version
       run: |
-        $publishDir = Get-Item -Path $WorkingDirectory -Name publish -ItemType Directory
+        tree
+        $publishDir = Get-Item -Path $env:GITHUB_WORKSPACE -Name publish -ItemType Directory
         [version]$version = (Import-PowerShellDataFile -Path "$($publishDir.FullName)\d365bap.tools\d365bap.tools.psd1").ModuleVersion
         $githubReleaseVersion = "$($version.Major).$($version.Minor).$($version.Build)"
         "VERSION=$githubReleaseVersion" >> $env:GITHUB_ENV

--- a/.github/workflows/tmpl-build-release.yml
+++ b/.github/workflows/tmpl-build-release.yml
@@ -18,6 +18,11 @@ on:
         default: $False
         required: false
         type: string
+      skipghrelease:
+        description: "Determines if a GitHub release is created"
+        default: $False
+        required: false
+        type: string
     secrets:
       apikey:
         description: "Key for the PowerShell Gallery API"
@@ -39,3 +44,20 @@ jobs:
     - name: Build
       run: .\build\vsts-build.ps1 -ApiKey ${{ secrets.apikey }} -AutoVersion:${{ inputs.autoversion }} -SkipPublish:${{ inputs.skippublish }}
       shell: powershell
+    
+    - name: Get version
+      run: |
+        $publishDir = Get-Item -Path $WorkingDirectory -Name publish -ItemType Directory
+        [version]$version = (Import-PowerShellDataFile -Path "$($publishDir.FullName)\d365bap.tools\d365bap.tools.psd1").ModuleVersion
+        $githubReleaseVersion = "$($version.Major).$($version.Minor).$($version.Build)"
+        "VERSION=$githubReleaseVersion" >> $env:GITHUB_ENV
+      shell: powershell
+
+    - name: Create GitHub release
+      uses: softprops/action-gh-release@v2
+      with:
+        name: ${{ env.VERSION }}
+        tag_name: ${{ env.VERSION }}
+        draft: false
+        prerelease: true
+        generate_release_notes: true

--- a/.github/workflows/tmpl-build-release.yml
+++ b/.github/workflows/tmpl-build-release.yml
@@ -47,8 +47,7 @@ jobs:
     
     - name: Get version
       run: |
-        tree
-        $publishDir = Get-Item -Path $env:GITHUB_WORKSPACE -Name publish -ItemType Directory
+        $publishDir = Get-Item -Path publish -ItemType Directory
         [version]$version = (Import-PowerShellDataFile -Path "$($publishDir.FullName)\d365bap.tools\d365bap.tools.psd1").ModuleVersion
         $githubReleaseVersion = "$($version.Major).$($version.Minor).$($version.Build)"
         "VERSION=$githubReleaseVersion" >> $env:GITHUB_ENV

--- a/.github/workflows/tmpl-build-release.yml
+++ b/.github/workflows/tmpl-build-release.yml
@@ -1,0 +1,41 @@
+# Template for a reusable workflow to build and release a PowerShell module.
+# The template expects the following PowerShell scripts in the build folder of the repository root
+# that do the actual validated build and release:
+# - vsts-prerequisities.ps1
+# - vsts-validate.ps1
+# - vsts-build.ps1
+
+on:
+  workflow_call:
+    inputs:
+      autoversion:
+        description: "Determines if the module's build version number is automatically incremented"
+        default: true
+        required: false
+        type: boolean
+      skippublish:
+        description: "Determines if the publishing to the PowerShell Gallery is skipped"
+        default: false
+        required: false
+        type: boolean
+    secrets:
+      apikey:
+        description: "Key for the PowerShell Gallery API"
+        required: true
+
+jobs:
+  build-and-release:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install Prerequisites
+      run: .\build\vsts-prerequisites.ps1
+      shell: powershell
+    - name: Validate
+      run: .\build\vsts-validate.ps1
+      shell: powershell
+    - name: Build
+      run: .\build\vsts-build.ps1 -ApiKey ${{ secrets.apikey }} -AutoVersion:${{ inputs.autoversion }} -SkipPublish:${{ inputs.skippublish }}
+      shell: powershell


### PR DESCRIPTION
This extends the build GitHub action by adding a step to automatically create a GitHub release.

As preparation of consolidating all actions shared by the d365collaborative repositories, the actual build steps were moved into a [reusable workflow](https://docs.github.com/en/actions/using-workflows/reusing-workflows).

To demonstrate the reusable workflow, a new build action was added that can be triggered manually and allows disabling the release creation on both PowerShell gallery and GitHub. This is mainly intended for testing the reusable workflow.