### PR TITLE
add information about recommended PowerShell edition

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Available on PowerShell Gallery:
 * [Dependencies](#dependencies)
 
 ## Getting started
+
+It is recommended to use the Core edition of PowerShell (i.e. [PowerShell 7](https://learn.microsoft.com/en-us/powershell/scripting/install/install-powershell-on-windows)). d365bap.tools can be used in the Desktop edition (i.e. Windows PowerShell 5.1), but not all commands will work there.
+
 ### Install the latest module
 ```PowerShell
 Install-Module -Name d365bap.tools

--- a/d365bap.tools/d365bap.tools.psd1
+++ b/d365bap.tools/d365bap.tools.psd1
@@ -21,6 +21,7 @@
 	Description       = 'Tools used for Business Application Platform, One Dynamics One Platform - D365FO + Dataverse'
 	
 	# Minimum version of the Windows PowerShell engine required by this module
+	# Some commands require PowerShell 7, but the module can still be imported in 5.0
 	PowerShellVersion = '5.0'
 	
 	# Modules that must be imported into the global environment prior to importing


### PR DESCRIPTION
These changes make it clearer that d365bap.tools is written for and intended to be used in PowerShell Core.