### PR TITLE
`New-UnifiedEnvironment` in environment group #133

### DIFF
--- a/d365bap.tools/d365bap.tools.psd1
+++ b/d365bap.tools/d365bap.tools.psd1
@@ -168,6 +168,7 @@
 		, 'Get-PpacD365OperationHistory'
 		, 'Get-PpacD365PlatformUpdate'
 		, 'Get-PpacDeployLocation'
+		, 'Get-PpacEnvironmentGroup'
 		, 'Get-PpacRbacRole'
 		, 'Get-PpacRbacRoleMember'
 

--- a/d365bap.tools/functions/Get-PpacEnvironmentGroup.ps1
+++ b/d365bap.tools/functions/Get-PpacEnvironmentGroup.ps1
@@ -1,33 +1,34 @@
+﻿
 <#
     .SYNOPSIS
         Retrieves Power Platform environment groups.
-
+        
     .DESCRIPTION
         Retrieves environment groups from the Power Platform API.
-
+        
     .PARAMETER EnvironmentGroup
         Filters environment groups by ID, display name, or description.
-
+        
         Supports wildcard characters.
-
+        
     .PARAMETER AsExcelOutput
         Instructs the cmdlet to export the output to an Excel file.
-
+        
     .EXAMPLE
         PS C:\> Get-PpacEnvironmentGroup
-
+        
         Retrieves all environment groups available to the current tenant.
-
+        
     .EXAMPLE
         PS C:\> Get-PpacEnvironmentGroup -EnvironmentGroup "*Production*"
-
+        
         Retrieves environment groups whose ID, display name, or description contains "Production".
-
+        
     .EXAMPLE
         PS C:\> Get-PpacEnvironmentGroup -AsExcelOutput
-
+        
         Retrieves all environment groups and exports them to an Excel file.
-
+        
     .NOTES
         Author: Florian Hopfner (@FH-Inway)
 #>

--- a/d365bap.tools/functions/Get-PpacEnvironmentGroup.ps1
+++ b/d365bap.tools/functions/Get-PpacEnvironmentGroup.ps1
@@ -72,12 +72,9 @@ function Get-PpacEnvironmentGroup {
                 -Property "id as Id",
             "displayName as DisplayName",
             "description as Description",
-            "parentGroupId as ParentGroupId",
-            @{Name = "ChildrenGroupIds"; Expression = { $_.childrenGroupIds } },
-            @{Name = "ChildrenGroupIdsList"; Expression = { $_.childrenGroupIds -join ", " } },
-            @{Name = "CreatedBy"; Expression = { $_.createdBy.displayName } },
+            "createdBy.id as CreatedBy",
             "createdTime as CreatedTime",
-            @{Name = "LastModifiedBy"; Expression = { $_.lastModifiedBy.displayName } },
+            "lastModifiedBy.id as LastModifiedBy",
             "lastModifiedTime as LastModifiedTime"
         )
 

--- a/d365bap.tools/functions/Get-PpacEnvironmentGroup.ps1
+++ b/d365bap.tools/functions/Get-PpacEnvironmentGroup.ps1
@@ -1,0 +1,92 @@
+<#
+    .SYNOPSIS
+        Retrieves Power Platform environment groups.
+
+    .DESCRIPTION
+        Retrieves environment groups from the Power Platform API.
+
+    .PARAMETER EnvironmentGroup
+        Filters environment groups by ID, display name, or description.
+
+        Supports wildcard characters.
+
+    .PARAMETER AsExcelOutput
+        Instructs the cmdlet to export the output to an Excel file.
+
+    .EXAMPLE
+        PS C:\> Get-PpacEnvironmentGroup
+
+        Retrieves all environment groups available to the current tenant.
+
+    .EXAMPLE
+        PS C:\> Get-PpacEnvironmentGroup -EnvironmentGroup "*Production*"
+
+        Retrieves environment groups whose ID, display name, or description contains "Production".
+
+    .EXAMPLE
+        PS C:\> Get-PpacEnvironmentGroup -AsExcelOutput
+
+        Retrieves all environment groups and exports them to an Excel file.
+
+    .NOTES
+        Author: Florian Hopfner (@FH-Inway)
+#>
+function Get-PpacEnvironmentGroup {
+    [CmdletBinding()]
+    [OutputType('System.Object[]')]
+    param (
+        [Alias('GroupId', 'GroupName', 'GroupDescription')]
+        [string] $EnvironmentGroup = "*",
+
+        [switch] $AsExcelOutput
+    )
+
+    begin {
+        $secureToken = (Get-AzAccessToken -ResourceUrl "https://api.powerplatform.com/" -AsSecureString -ErrorAction Stop).Token
+        $tokenValue = ConvertFrom-SecureString -AsPlainText -SecureString $secureToken
+
+        $headers = @{
+            Authorization = "Bearer $tokenValue"
+        }
+
+        $uri = "https://api.powerplatform.com/environmentmanagement/environmentGroups?api-version=2024-10-01"
+        $environmentGroups = @()
+    }
+
+    process {
+        if (Test-PSFFunctionInterrupt) { return }
+
+        while (-not [string]::IsNullOrWhiteSpace($uri)) {
+            $result = Invoke-RestMethod -Method Get -Uri $uri -Headers $headers
+
+            $environmentGroups += $result.value
+            $uri = $result.'@odata.nextLink'
+        }
+
+        $resCol = @(
+            $environmentGroups | Where-Object {
+                $_.id -like $EnvironmentGroup `
+                -or $_.displayName -like $EnvironmentGroup `
+                -or $_.description -like $EnvironmentGroup
+            } | Select-PSFObject -TypeName "D365Bap.Tools.PpacEnvironmentGroup" `
+                -Property "id as Id",
+            "displayName as DisplayName",
+            "description as Description",
+            "parentGroupId as ParentGroupId",
+            @{Name = "ChildrenGroupIds"; Expression = { $_.childrenGroupIds } },
+            @{Name = "ChildrenGroupIdsList"; Expression = { $_.childrenGroupIds -join ", " } },
+            @{Name = "CreatedBy"; Expression = { $_.createdBy.displayName } },
+            "createdTime as CreatedTime",
+            @{Name = "LastModifiedBy"; Expression = { $_.lastModifiedBy.displayName } },
+            "lastModifiedTime as LastModifiedTime"
+        )
+
+        if ($AsExcelOutput) {
+            $resCol | Export-Excel -WorksheetName "Get-PpacEnvironmentGroup" `
+                -WarningAction SilentlyContinue
+            return
+        }
+
+        $resCol
+    }
+}

--- a/d365bap.tools/functions/New-UnifiedEnvironment.ps1
+++ b/d365bap.tools/functions/New-UnifiedEnvironment.ps1
@@ -49,6 +49,11 @@
         
     .PARAMETER SecurityGroup
         Entra Groups security group to restrict access to the new environment.
+
+    .PARAMETER EnvironmentGroup
+        The ID or display name of the environment group in which to create the shell environment.
+
+        Note that this will make the environment a managed environment.
         
     .PARAMETER PostProvisionDelaySeconds
         Additional delay (in seconds) after the shell environment reports as ready.
@@ -124,6 +129,25 @@
         It will get a default/unique domain name assigned by Power Platform.
         It will take the latest available version of Finance and Operations.
         It will restrict access to the environment to members of the specified Entra Groups security group "MySecurityGroup".
+
+    .EXAMPLE
+        PS C:\> New-UnifiedEnvironment -Type "UDE" -Name "MyUdeEnv" -Location "Europe" -EnvironmentGroup "D365FO"
+        
+        This will create a new Unified Developer Environment (UDE) named "MyUdeEnv" in the "Europe" location.
+        It will include a demo database by default.
+        It will get a default/unique domain name assigned by Power Platform.
+        It will take the latest available version of Finance and Operations.
+        It will deploy into the "D365FO" environment group. The environment group could also be specified by its ID (a guid like "12345678-1234-1234-1234-123456789abc").
+        
+    .EXAMPLE
+        PS C:\> New-UnifiedEnvironment -Type "UDE" -Name "MyUdeEnv" -Location "Europe" -EarlyRelease
+        
+        This will create a new Unified Developer Environment (UDE) named "MyUdeEnv" in the "Europe" location.
+        The environment will be in the early release cycle.
+        It will include a demo database by default.
+        It will get a default/unique domain name assigned by Power Platform.
+        It will take the latest available version of Finance and Operations.
+        It will not restrict access to the environment.
         
     .EXAMPLE
         PS C:\> New-UnifiedEnvironment -Type "UDE" -Name "MyUdeEnv" -Location "Europe" -EarlyRelease
@@ -165,6 +189,9 @@ function New-UnifiedEnvironment {
         [Alias('EntraGroup')]
         [string] $SecurityGroup,
 
+        [Alias('EnvironmentGroupId', 'EnvironmentGroupName')]
+        [string] $EnvironmentGroup,
+
         [ValidateRange(0, 300)]
         [int] $PostProvisionDelaySeconds = 60,
 
@@ -178,6 +205,7 @@ function New-UnifiedEnvironment {
     
     begin {
         $SecurityGroupId = $null
+        $EnvironmentGroupId = $null
 
         $secureTokenBap = (Get-AzAccessToken -ResourceUrl "https://service.powerapps.com/" -AsSecureString).Token
         $tokenBapValue = ConvertFrom-SecureString -AsPlainText -SecureString $secureTokenBap
@@ -194,6 +222,31 @@ function New-UnifiedEnvironment {
                 -Group $SecurityGroup | `
                 Select-Object -ExpandProperty id
         }
+
+        if ($EnvironmentGroup) {
+            $environmentGroupGuid = [guid]::Empty
+
+            if ([guid]::TryParse($EnvironmentGroup, [ref] $environmentGroupGuid)) {
+                $EnvironmentGroupId = $environmentGroupGuid.ToString()
+            }
+            else {
+                $matchingEnvironmentGroups = @(Get-PpacEnvironmentGroup -EnvironmentGroup $EnvironmentGroup | Where-Object {
+                    $_.DisplayName -eq $EnvironmentGroup
+                })
+
+                if ($matchingEnvironmentGroups.Count -eq 0) {
+                    Stop-PSFFunction -Message "Environment group '$EnvironmentGroup' was not found. Use Get-PpacEnvironmentGroup to list available environment groups."
+                    return
+                }
+
+                if ($matchingEnvironmentGroups.Count -gt 1) {
+                    Stop-PSFFunction -Message "Environment group name '$EnvironmentGroup' is ambiguous. Specify the environment group ID instead. Use Get-PpacEnvironmentGroup to list available environment groups."
+                    return
+                }
+
+                $EnvironmentGroupId = $matchingEnvironmentGroups[0].Id
+            }
+        }
         
         if (Test-PSFFunctionInterrupt) { return }
     }
@@ -208,6 +261,7 @@ function New-UnifiedEnvironment {
             Region                   = $Region
             CustomDomainName         = $CustomDomainName
             SecurityGroupId          = $SecurityGroupId
+            EnvironmentGroupId       = $EnvironmentGroupId
             PostProvisionDelaySeconds = $PostProvisionDelaySeconds
             ReadyStateTimeoutMinutes  = $ReadyStateTimeoutMinutes
             EarlyRelease              = $EarlyRelease
@@ -274,6 +328,8 @@ function New-ShellEnvironment {
 
         [string] $SecurityGroupId,
 
+        [string] $EnvironmentGroupId,
+
         [Parameter(Mandatory = $true)]
         [int] $PostProvisionDelaySeconds,
 
@@ -328,6 +384,15 @@ function New-ShellEnvironment {
                 -Value ([PsCustomObject][ordered]@{
                     category = "FirstRelease"
                 })
+    }
+
+    if ($EnvironmentGroupId) {
+        $config.properties | `
+            Add-Member -MemberType NoteProperty `
+            -Name parentEnvironmentGroup `
+            -Value ([PsCustomObject]@{
+                id = $EnvironmentGroupId
+            })
     }
 
     $payload = $config | ConvertTo-Json -Depth 10

--- a/d365bap.tools/functions/New-UnifiedEnvironment.ps1
+++ b/d365bap.tools/functions/New-UnifiedEnvironment.ps1
@@ -49,10 +49,10 @@
         
     .PARAMETER SecurityGroup
         Entra Groups security group to restrict access to the new environment.
-
+        
     .PARAMETER EnvironmentGroup
         The ID or display name of the environment group in which to create the shell environment.
-
+        
         Note that this will make the environment a managed environment.
         
     .PARAMETER PostProvisionDelaySeconds
@@ -129,7 +129,7 @@
         It will get a default/unique domain name assigned by Power Platform.
         It will take the latest available version of Finance and Operations.
         It will restrict access to the environment to members of the specified Entra Groups security group "MySecurityGroup".
-
+        
     .EXAMPLE
         PS C:\> New-UnifiedEnvironment -Type "UDE" -Name "MyUdeEnv" -Location "Europe" -EnvironmentGroup "D365FO"
         

--- a/d365bap.tools/tests/functions/Get-PpacEnvironmentGroup.Tests.ps1
+++ b/d365bap.tools/tests/functions/Get-PpacEnvironmentGroup.Tests.ps1
@@ -1,0 +1,62 @@
+﻿Describe "Get-PpacEnvironmentGroup Unit Tests" -Tag "Unit" {
+	BeforeAll {
+		# Place here all things needed to prepare for the tests
+	}
+	AfterAll {
+		# Here is where all the cleanup tasks go
+	}
+	
+	Describe "Ensuring unchanged command signature" {
+		It "should have the expected parameter sets" {
+			(Get-Command Get-PpacEnvironmentGroup).ParameterSets.Name | Should -Be '__AllParameterSets'
+		}
+		
+		It 'Should have the expected parameter EnvironmentGroup' {
+			$parameter = (Get-Command Get-PpacEnvironmentGroup).Parameters['EnvironmentGroup']
+			$parameter.Name | Should -Be 'EnvironmentGroup'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 0
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter AsExcelOutput' {
+			$parameter = (Get-Command Get-PpacEnvironmentGroup).Parameters['AsExcelOutput']
+			$parameter.Name | Should -Be 'AsExcelOutput'
+			$parameter.ParameterType.ToString() | Should -Be System.Management.Automation.SwitchParameter
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+		It 'Should have the expected parameter ProgressAction' {
+			$parameter = (Get-Command Get-PpacEnvironmentGroup).Parameters['ProgressAction']
+			$parameter.Name | Should -Be 'ProgressAction'
+			$parameter.ParameterType.ToString() | Should -Be System.Management.Automation.ActionPreference
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be -2147483648
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
+	}
+	
+	Describe "Testing parameterset __AllParameterSets" {
+		<#
+		__AllParameterSets -
+		__AllParameterSets -EnvironmentGroup -AsExcelOutput -ProgressAction
+		#>
+	}
+
+}

--- a/d365bap.tools/tests/functions/New-UnifiedEnvironment.Tests.ps1
+++ b/d365bap.tools/tests/functions/New-UnifiedEnvironment.Tests.ps1
@@ -115,6 +115,19 @@
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
 		}
+		It 'Should have the expected parameter EnvironmentGroup' {
+			$parameter = (Get-Command New-UnifiedEnvironment).Parameters['EnvironmentGroup']
+			$parameter.Name | Should -Be 'EnvironmentGroup'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 7
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
 		It 'Should have the expected parameter PostProvisionDelaySeconds' {
 			$parameter = (Get-Command New-UnifiedEnvironment).Parameters['PostProvisionDelaySeconds']
 			$parameter.Name | Should -Be 'PostProvisionDelaySeconds'
@@ -123,7 +136,7 @@
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 7
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 8
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
@@ -136,7 +149,7 @@
 			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
 			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
 			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
-			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 8
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 9
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
@@ -185,7 +198,7 @@
 	Describe "Testing parameterset __AllParameterSets" {
 		<#
 		__AllParameterSets -Type -Name -Location
-		__AllParameterSets -Type -Name -CustomDomainName -Location -Region -NoDemoDb -Version -SecurityGroup -PostProvisionDelaySeconds -ReadyStateTimeoutMinutes -WaitForCompletion -EarlyRelease -ProgressAction
+		__AllParameterSets -Type -Name -CustomDomainName -Location -Region -NoDemoDb -Version -SecurityGroup -EnvironmentGroup -PostProvisionDelaySeconds -ReadyStateTimeoutMinutes -WaitForCompletion -EarlyRelease -ProgressAction
 		#>
 	}
 

--- a/docs/Get-PpacEnvironmentGroup.md
+++ b/docs/Get-PpacEnvironmentGroup.md
@@ -1,0 +1,106 @@
+﻿---
+external help file: d365bap.tools-help.xml
+Module Name: d365bap.tools
+online version:
+schema: 2.0.0
+---
+
+# Get-PpacEnvironmentGroup
+
+## SYNOPSIS
+Retrieves Power Platform environment groups.
+
+## SYNTAX
+
+```
+Get-PpacEnvironmentGroup [[-EnvironmentGroup] <String>] [-AsExcelOutput] [-ProgressAction <ActionPreference>]
+ [<CommonParameters>]
+```
+
+## DESCRIPTION
+Retrieves environment groups from the Power Platform API.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Get-PpacEnvironmentGroup
+```
+
+Retrieves all environment groups available to the current tenant.
+
+### EXAMPLE 2
+```
+Get-PpacEnvironmentGroup -EnvironmentGroup "*Production*"
+```
+
+Retrieves environment groups whose ID, display name, or description contains "Production".
+
+### EXAMPLE 3
+```
+Get-PpacEnvironmentGroup -AsExcelOutput
+```
+
+Retrieves all environment groups and exports them to an Excel file.
+
+## PARAMETERS
+
+### -EnvironmentGroup
+Filters environment groups by ID, display name, or description.
+
+Supports wildcard characters.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: GroupId, GroupName, GroupDescription
+
+Required: False
+Position: 1
+Default value: *
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AsExcelOutput
+Instructs the cmdlet to export the output to an Excel file.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+### System.Object[]
+## NOTES
+Author: Florian Hopfner (@FH-Inway)
+
+## RELATED LINKS

--- a/docs/New-UnifiedEnvironment.md
+++ b/docs/New-UnifiedEnvironment.md
@@ -15,8 +15,8 @@ Deploy a new Unified Environment in Power Platform Admin Center (PPAC).
 ```
 New-UnifiedEnvironment [-Type] <String> [-Name] <String> [[-CustomDomainName] <String>] [-Location] <String>
  [[-Region] <String>] [-NoDemoDb] [[-Version] <Version>] [[-SecurityGroup] <String>]
- [[-PostProvisionDelaySeconds] <Int32>] [[-ReadyStateTimeoutMinutes] <Int32>] [-WaitForCompletion]
- [-EarlyRelease] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [[-EnvironmentGroup] <String>] [[-PostProvisionDelaySeconds] <Int32>] [[-ReadyStateTimeoutMinutes] <Int32>]
+ [-WaitForCompletion] [-EarlyRelease] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -96,6 +96,30 @@ It will take the latest available version of Finance and Operations.
 It will restrict access to the environment to members of the specified Entra Groups security group "MySecurityGroup".
 
 ### EXAMPLE 7
+```
+New-UnifiedEnvironment -Type "UDE" -Name "MyUdeEnv" -Location "Europe" -EnvironmentGroup "D365FO"
+```
+
+This will create a new Unified Developer Environment (UDE) named "MyUdeEnv" in the "Europe" location.
+It will include a demo database by default.
+It will get a default/unique domain name assigned by Power Platform.
+It will take the latest available version of Finance and Operations.
+It will deploy into the "D365FO" environment group.
+The environment group could also be specified by its ID (a guid like "12345678-1234-1234-1234-123456789abc").
+
+### EXAMPLE 8
+```
+New-UnifiedEnvironment -Type "UDE" -Name "MyUdeEnv" -Location "Europe" -EarlyRelease
+```
+
+This will create a new Unified Developer Environment (UDE) named "MyUdeEnv" in the "Europe" location.
+The environment will be in the early release cycle.
+It will include a demo database by default.
+It will get a default/unique domain name assigned by Power Platform.
+It will take the latest available version of Finance and Operations.
+It will not restrict access to the environment.
+
+### EXAMPLE 9
 ```
 New-UnifiedEnvironment -Type "UDE" -Name "MyUdeEnv" -Location "Europe" -EarlyRelease
 ```
@@ -248,6 +272,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -EnvironmentGroup
+The ID or display name of the environment group in which to create the shell environment.
+
+Note that this will make the environment a managed environment.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases: EnvironmentGroupId, EnvironmentGroupName
+
+Required: False
+Position: 8
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -PostProvisionDelaySeconds
 Additional delay (in seconds) after the shell environment reports as ready.
 
@@ -259,7 +300,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 8
+Position: 9
 Default value: 60
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -276,7 +317,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 9
+Position: 10
 Default value: 60
 Accept pipeline input: False
 Accept wildcard characters: False


### PR DESCRIPTION
This pull request introduces the ability to specify an environment group when creating a new Unified Environment, making the environment a managed environment in the specified environment group. It does this by adding a new `-EnvironmentGroup` parameter to the `New-UnifiedEnvironment` function, supporting both group IDs and display names, and by implementing a new `Get-PpacEnvironmentGroup` cmdlet to retrieve available environment groups. The changes also update the documentation and ensure the environment group is passed through to the shell environment creation logic.

Implements #133 