### PR TITLE
fix: check AzCopy exists before downloading UDE developer files

### DIFF
--- a/d365bap.tools/functions/Get-UdeDeveloperFile.ps1
+++ b/d365bap.tools/functions/Get-UdeDeveloperFile.ps1
@@ -156,6 +156,13 @@ function Get-UdeDeveloperFile {
             return
         }
 
+        if (-not [System.IO.File]::Exists($executable)) {
+            $messageString = "AzCopy executable not found at <c='em'>$executable</c>. Please install AzCopy using <c='em'>Invoke-BapInstallAzCopy</c> or configure the path using <c='em'>Set-BapAzCopyPath</c>."
+            Write-PSFMessage -Level Important -Message $messageString
+            Stop-PSFFunction -Message "Stopping because AzCopy executable was not found." -Exception $([System.Exception]::new($($messageString -replace '<[^>]+>', '')))
+            return
+        }
+
         Write-PSFMessage -Level Important -Message "Will start the download of the files. It will open a separate PowerShell window for each:"
 
         $retryCount = 0


### PR DESCRIPTION
Get-UdeDeveloperFile now validates the AzCopy executable exists before starting downloads when -Download is specified. Uses PSFMessage with install hint (Invoke-BapInstallAzCopy / Set-BapAzCopyPath) instead of silently failing.