### PR TITLE
Add -Name filter and TEPP autocomplete to Compare-BapEnvironmentVirtu…

### DIFF
--- a/d365bap.tools/functions/Compare-BapEnvironmentVirtualEntity.ps1
+++ b/d365bap.tools/functions/Compare-BapEnvironmentVirtualEntity.ps1
@@ -14,6 +14,22 @@
     .PARAMETER DestinationEnvironmentId
         Environment Id of the destination environment that you want to validate against the baseline (source)
         
+    .PARAMETER Name
+        The name of the virtual entity that you are looking for
+        
+        The parameter supports wildcards, but will resolve them into a strategy that matches best practice from Microsoft documentation
+        
+        It means that you can only have a single search phrase. E.g.
+        * -Name "*Retail"
+        * -Name "Retail*"
+        * -Name "*Retail*"
+        
+        Multiple search phrases are not going to produce an output, as it will be striped into an invalid search string. E.g.
+        ! -Name "*Retail*Entity*" -> "RetailEntity"
+        ! -Name "Retail*Entity" -> "RetailEntity"
+        ! -Name "*Retail*Entity" -> "RetailEntity"
+        ! -Name "Retail*Entity*" -> "RetailEntity"
+        
     .PARAMETER ShowDiffOnly
         Instruct the cmdlet to only output the differences that are not aligned between the source and destination
         
@@ -51,6 +67,12 @@
         WMHEOutboundQueueEntity        True            False                       False       False
         
     .EXAMPLE
+        PS C:\> Compare-BapEnvironmentVirtualEntity -SourceEnvironmentId eec2c11a-a4c7-4e1d-b8ed-f62acc9c74c6 -DestinationEnvironmentId 32c6b196-ef52-4c43-93cf-6ecba51e6aa1 -Name "Retail*"
+        
+        This will get all enabled / visible Virtual Entities that contains the "Retail" text in the name, from the Source Environment.
+        It will iterate over all of them, and validate against the Destination Environment.
+        
+    .EXAMPLE
         PS C:\> Compare-BapEnvironmentVirtualEntity -SourceEnvironmentId eec2c11a-a4c7-4e1d-b8ed-f62acc9c74c6 -DestinationEnvironmentId 32c6b196-ef52-4c43-93cf-6ecba51e6aa1
         
         This will get all enabled / visible Virtual Entities from the Source Environment.
@@ -68,6 +90,8 @@ function Compare-BapEnvironmentVirtualEntity {
 
         [Parameter (Mandatory = $true)]
         [string] $DestinationEnvironmentId,
+
+        [string] $Name = "*",
 
         [switch] $ShowDiffOnly,
 
@@ -95,7 +119,7 @@ function Compare-BapEnvironmentVirtualEntity {
 
         if (Test-PSFFunctionInterrupt) { return }
 
-        $entitiesSourceEnvironment = @(Get-BapEnvironmentVirtualEntity -EnvironmentId $SourceEnvironmentId -VisibleOnly)
+        $entitiesSourceEnvironment = @(Get-BapEnvironmentVirtualEntity -EnvironmentId $SourceEnvironmentId -VisibleOnly -Name $Name)
         $entitiesDestinationEnvironment = @(
             foreach ($entName in $entitiesSourceEnvironment.EntityName) {
                 Get-BapEnvironmentVirtualEntity -EnvironmentId $DestinationEnvironmentId -Name $entName

--- a/d365bap.tools/internal/tepp/environments.tepp.ps1
+++ b/d365bap.tools/internal/tepp/environments.tepp.ps1
@@ -10,8 +10,12 @@ Register-PSFTeppScriptblock -Name "d365bap.tools.tepp.environments" -ScriptBlock
     Get-PSFTaskEngineCache -Module d365bap.tools -Name Environments
 }
 
-$commands = Get-Command -Module d365bap.tools | Where-Object { $_.Parameters.Keys -contains "EnvironmentId" }
+$teppParameters = @("EnvironmentId", "SourceEnvironmentId", "DestinationEnvironmentId")
 
-foreach ($command in $commands) {
-    Register-PSFTeppArgumentCompleter -Command $command.Name -Parameter EnvironmentId -Name "d365bap.tools.tepp.environments"
+foreach ($paramName in $teppParameters) {
+    $commands = Get-Command -Module d365bap.tools | Where-Object { $_.Parameters.Keys -contains $paramName }
+
+    foreach ($command in $commands) {
+        Register-PSFTeppArgumentCompleter -Command $command.Name -Parameter $paramName -Name "d365bap.tools.tepp.environments"
+    }
 }

--- a/d365bap.tools/tests/functions/Compare-BapEnvironmentVirtualEntity.Tests.ps1
+++ b/d365bap.tools/tests/functions/Compare-BapEnvironmentVirtualEntity.Tests.ps1
@@ -37,6 +37,19 @@
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
 			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
 		}
+		It 'Should have the expected parameter Name' {
+			$parameter = (Get-Command Compare-BapEnvironmentVirtualEntity).Parameters['Name']
+			$parameter.Name | Should -Be 'Name'
+			$parameter.ParameterType.ToString() | Should -Be System.String
+			$parameter.IsDynamic | Should -Be $False
+			$parameter.ParameterSets.Keys | Should -Be '__AllParameterSets'
+			$parameter.ParameterSets.Keys | Should -Contain '__AllParameterSets'
+			$parameter.ParameterSets['__AllParameterSets'].IsMandatory | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].Position | Should -Be 2
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipeline | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromPipelineByPropertyName | Should -Be $False
+			$parameter.ParameterSets['__AllParameterSets'].ValueFromRemainingArguments | Should -Be $False
+		}
 		It 'Should have the expected parameter ShowDiffOnly' {
 			$parameter = (Get-Command Compare-BapEnvironmentVirtualEntity).Parameters['ShowDiffOnly']
 			$parameter.Name | Should -Be 'ShowDiffOnly'
@@ -81,7 +94,7 @@
 	Describe "Testing parameterset __AllParameterSets" {
 		<#
 		__AllParameterSets -SourceEnvironmentId -DestinationEnvironmentId
-		__AllParameterSets -SourceEnvironmentId -DestinationEnvironmentId -ShowDiffOnly -AsExcelOutput -ProgressAction
+		__AllParameterSets -SourceEnvironmentId -DestinationEnvironmentId -Name -ShowDiffOnly -AsExcelOutput -ProgressAction
 		#>
 	}
 

--- a/docs/Compare-BapEnvironmentVirtualEntity.md
+++ b/docs/Compare-BapEnvironmentVirtualEntity.md
@@ -14,7 +14,7 @@ Compare environment Virtual Entities
 
 ```
 Compare-BapEnvironmentVirtualEntity [-SourceEnvironmentId] <String> [-DestinationEnvironmentId] <String>
- [-ShowDiffOnly] [-AsExcelOutput] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ [[-Name] <String>] [-ShowDiffOnly] [-AsExcelOutput] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -58,6 +58,14 @@ WMHEOutboundQueueEntity        True            False                       False
 
 ### EXAMPLE 3
 ```
+Compare-BapEnvironmentVirtualEntity -SourceEnvironmentId eec2c11a-a4c7-4e1d-b8ed-f62acc9c74c6 -DestinationEnvironmentId 32c6b196-ef52-4c43-93cf-6ecba51e6aa1 -Name "Retail*"
+```
+
+This will get all enabled / visible Virtual Entities that contains the "Retail" text in the name, from the Source Environment.
+It will iterate over all of them, and validate against the Destination Environment.
+
+### EXAMPLE 4
+```
 Compare-BapEnvironmentVirtualEntity -SourceEnvironmentId eec2c11a-a4c7-4e1d-b8ed-f62acc9c74c6 -DestinationEnvironmentId 32c6b196-ef52-4c43-93cf-6ecba51e6aa1
 ```
 
@@ -93,6 +101,40 @@ Aliases:
 Required: True
 Position: 2
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Name
+The name of the virtual entity that you are looking for
+
+The parameter supports wildcards, but will resolve them into a strategy that matches best practice from Microsoft documentation
+
+It means that you can only have a single search phrase.
+E.g.
+* -Name "*Retail"
+* -Name "Retail*"
+* -Name "*Retail*"
+
+Multiple search phrases are not going to produce an output, as it will be striped into an invalid search string.
+E.g.
+!
+-Name "*Retail*Entity*" -\> "RetailEntity"
+!
+-Name "Retail*Entity" -\> "RetailEntity"
+!
+-Name "*Retail*Entity" -\> "RetailEntity"
+!
+-Name "Retail*Entity*" -\> "RetailEntity"
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: *
 Accept pipeline input: False
 Accept wildcard characters: False
 ```


### PR DESCRIPTION
…alEntity

Wire SourceEnvironmentId/DestinationEnvironmentId into the environments TEPP registration. Add optional -Name parameter (default *) passed through to the source baseline query, matching Get-BapEnvironmentVirtualEntity filtering. Regenerate parameter tests and docs.